### PR TITLE
Printing the pattern that causes a file to fail.

### DIFF
--- a/tasks/lib/regex-check.js
+++ b/tasks/lib/regex-check.js
@@ -38,19 +38,26 @@ var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile) {
                     } else {
                         return true;
                     }
-                }).filter(function (filepath) {
-                        ranOnce = true;
-                        var source = file.read(filepath);
-                        var matchesPattern = source.match(pattern) !== null;
-                        var isNotExcluded = !isExcluded(filepath, excludedFiles);
-                        return matchesPattern && isNotExcluded;
+                }).map(function (filepath) {
+                    ranOnce = true;
+                    var source = file.read(filepath);
+                    var match = source.match(pattern);
+                    return {
+                      filepath: filepath,
+                      match: match,
+                      isNotExcluded: !isExcluded(filepath, excludedFiles)
+                    };
+                }).filter(function (result) {
+                    return result.match !== null && result.isNotExcluded;
                     });
 
-                var allFiles = matchingFiles.join('\n');
                 if (matchingFiles.length === 0) {
                     log.writeln('grunt-regex-check passed');
                 } else {
-                    log.error("The following files contained unwanted patterns:\n\n" + allFiles +
+                    var filesMessages = matchingFiles.map(function (matchingFile) {
+                      return matchingFile.filepath + " - failed because it matched '" + matchingFile.match[0] + "'";
+                    }).join('\n');
+                    log.error("The following files contained unwanted patterns:\n\n" + filesMessages +
                         "\n\nFiles that were excluded:\n" + excludedFiles.join('\n'));
                 }
 


### PR DESCRIPTION
Hi Pat,

Thanks for writing this plugin, it has come in quite useful.

I made a quick tweak so that it includes the part of the regex pattern that caused a file to fail along with the file path in the error.

Cheers,

Mike
