### PR TITLE
Using grunt.fail.warn instead of just logging. 

### DIFF
--- a/tasks/lib/regex-check.js
+++ b/tasks/lib/regex-check.js
@@ -1,4 +1,5 @@
 'use strict';
+var grunt = require('grunt');
 
 var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile) {
     var log = gruntLog;
@@ -54,7 +55,7 @@ var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile) {
                     var filesMessages = matchingFiles.map(function (matchingFile) {
                       return matchingFile.filepath + " - failed because it matched '" + matchingFile.match[0] + "'";
                     }).join('\n');
-                    log.error("The following files contained unwanted patterns:\n\n" + filesMessages +
+                    grunt.fail.warn("The following files contained unwanted patterns:\n\n" + filesMessages +
                         "\n\nFiles that were excluded:\n" + excludedFiles.join('\n'));
                 }
 


### PR DESCRIPTION
This will make sure the grunt task fails when ran if any matches are found. Can still override with --force like always with grunt. Same issue reported in #1.
