### PR TITLE
Include the target name in the output.

### DIFF
--- a/tasks/lib/regex-check.js
+++ b/tasks/lib/regex-check.js
@@ -1,7 +1,7 @@
 'use strict';
 var grunt = require('grunt');
 
-var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile, warnOnly) {
+var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile, warnOnly, name) {
     var log = gruntLog;
     var file = gruntFile;
 
@@ -53,7 +53,7 @@ var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile, wa
                     log.writeln('grunt-regex-check passed');
                 } else {
                     var filesMessages = matchingFiles.map(function (matchingFile) {
-                      return matchingFile.filepath + " - failed because it matched '" + matchingFile.match[0] + "'";
+                      return name + ': ' + matchingFile.filepath + " - failed because it matched '" + matchingFile.match[0] + "'";
                     }).join('\n');
                     var msg = "The following files contained unwanted patterns:\n\n" + filesMessages +
                         "\n\nFiles that were excluded:\n" + excludedFiles.join('\n');

--- a/tasks/regex-check-task.js
+++ b/tasks/regex-check-task.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
         try {
             var pattern = options.pattern;
             var excluded = grunt.util._.flatten(expand(options.excluded));
-            var regexCheck = new RegexCheck(pattern, excluded, grunt.log, grunt.file, !options.breakOnError);
+            var regexCheck = new RegexCheck(pattern, excluded, grunt.log, grunt.file, !options.breakOnError, this.target);
             regexCheck.check(this.files);
         } catch (error) {
             grunt.log.error(error);


### PR DESCRIPTION
This makes it easier to see which rule was violated. For example, for a target
named 'console.log detected', we would have:

  console.log detected: src/app/card/batch-page/batch-page.js - failed because it matched 'console.log('
