### PR TITLE
Added the ability to fail the build if a pattern is missing from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ Type: `boolean`
 Default value: true
 Mandatory: false
 
-By setting to `false` you can only warn the user, but not break the build.
+#### options.failIfMissing
+Type: `boolean`
+Default value: false
+Mandatory: false
+
+By setting to `true` the file will be noted as failing if the pattern does NOT exist in the file.
 
 ### Usage Examples
 
@@ -76,6 +81,22 @@ grunt.initConfig({
       excluded : "src/**/*xcluded.js",
       pattern : /console/g,
       breakOnError: false
+    },
+  },
+})
+```
+
+__Example__: warns the user that the <!DOCTYPE html> is missing from the top of the file
+
+```js
+grunt.initConfig({
+  "regex-check": {
+    files: "src/**/*.html",
+    options: {
+      excluded : "src/**/*xcluded.html",
+      pattern : /^<!DOCTYPE html>/g,
+      breakOnError: false,
+      failIfMissing: true
     },
   },
 })

--- a/tasks/lib/regex-check.js
+++ b/tasks/lib/regex-check.js
@@ -2,7 +2,7 @@
 var grunt = require('grunt');
 var utils = require('./utils.js');
 
-var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile, warnOnly) {
+var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile, warnOnly, failIfMissing) {
 
     var log = gruntLog;
     var file = gruntFile;
@@ -24,7 +24,7 @@ var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile, wa
                     }
                 }).map(function (filepath) {
                     ranOnce = true;
-                    var result = utils.fileContentChecker(pattern, file.read(filepath), filepath, excludedFiles);
+                    var result = utils.fileContentChecker(pattern, file.read(filepath), filepath, excludedFiles, failIfMissing);
                     return result;
 
                 }).filter(function (result) {

--- a/tasks/lib/regex-check.js
+++ b/tasks/lib/regex-check.js
@@ -35,7 +35,12 @@ var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile, wa
                     log.writeln('grunt-regex-check passed');
                 } else {
                     var filesMessages = matchingFiles.map(function (matchingFile) {
-                        var message = matchingFile.filepath + " - failed because it matched following patterns : ";
+                        var message = matchingFile.filepath;
+                        if (failIfMissing) {
+                            meassage += " - failed because the following pattern was missing : ";
+                        } else {
+                            meassage += " - failed because it matched following patterns : ";
+                        }
                         var prefix = "";
                         matchingFile.matches.forEach(function (element) {
                             message += prefix + "'" + element + "'";

--- a/tasks/lib/regex-check.js
+++ b/tasks/lib/regex-check.js
@@ -37,9 +37,9 @@ var RegexCheck = function (pattern, listOfExcludedFiles, gruntLog, gruntFile, wa
                     var filesMessages = matchingFiles.map(function (matchingFile) {
                         var message = matchingFile.filepath;
                         if (failIfMissing) {
-                            meassage += " - failed because the following pattern was missing : ";
+                            message += " - failed because the following pattern was missing : ";
                         } else {
-                            meassage += " - failed because it matched following patterns : ";
+                            message += " - failed because it matched following patterns : ";
                         }
                         var prefix = "";
                         matchingFile.matches.forEach(function (element) {

--- a/tasks/lib/utils.js
+++ b/tasks/lib/utils.js
@@ -13,7 +13,10 @@ var utils =
         }
         if (failIfMissing) {
             if (matches.length === 0) {
-                matches = [pattern.toString()]
+                matches = [pattern.toString()];
+            } else if (matches.length > 0) {
+                // The file matched a pattern so we return that there were no problems.
+                matches = [];
             }
         }
         return {

--- a/tasks/lib/utils.js
+++ b/tasks/lib/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 var utils =
 {
-    fileContentChecker: function (pattern, source, filepath, excludedFiles) {
+    fileContentChecker: function (pattern, source, filepath, excludedFiles, failIfMissing) {
         var matches = [];
         var isExcluded = utils.isExcluded(filepath, excludedFiles);
         if (!isExcluded) {
@@ -10,6 +10,11 @@ var utils =
                 if (match)
                     matches.push(match);
             });
+        }
+        if (failIfMissing) {
+            if (matches.length === 0) {
+                matches = [pattern.toString()]
+            }
         }
         return {
             filepath: filepath,

--- a/tasks/regex-check-task.js
+++ b/tasks/regex-check-task.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
         try {
             var pattern = options.pattern;
             var excluded = grunt.util._.flatten(expand(options.excluded));
-            var regexCheck = new RegexCheck(pattern, excluded, grunt.log, grunt.file, !options.breakOnError);
+            var regexCheck = new RegexCheck(pattern, excluded, grunt.log, grunt.file, !options.breakOnError, options.failIfMissing);
             regexCheck.check(this.files);
         } catch (error) {
             grunt.log.error(error);

--- a/test/regex_check_test.js
+++ b/test/regex_check_test.js
@@ -68,5 +68,14 @@ describe("regex-check", function() {
             assert.equal(fileResult.matches.length,0);
         }));
 
+        it("should return match if no match for a pattern", sinon.test(function() {
+            var fileResult = utils.fileContentChecker([/nomatch/g], "text content", "filepath", [], false, true);
+            assert.equal(fileResult.matches.length, 1);
+        }));
+
+        it("should return no match if there is a match for a pattern", sinon.test(function() {
+            var fileResult = utils.fileContentChecker([/text/g], "text content", "filepath", [], false, true);
+            assert.equal(fileResult.matches.length, 0);
+        }));
     });
 });


### PR DESCRIPTION
Basically this adds the ability to perform the reverse of what it already performs.

If a pattern is missing in the file then the build fails.

This could be used to check copyright or if an html file is missing the <!DOCTYPE html> tag

It does this by checking if the matching array is empty at the end.  And if it is AND the failIfMissing param is true then it fills the matching array with the pattern that caused the failure.
